### PR TITLE
Add Quest performance logger and VR benchmark notes

### DIFF
--- a/Assets/1-Programming/QuestPerfLogger.cs
+++ b/Assets/1-Programming/QuestPerfLogger.cs
@@ -1,0 +1,50 @@
+using System.IO;
+using UnityEngine;
+using UnityEngine.XR;
+
+// Registro simple de métricas para Quest y otros visores XR.
+// Guarda CPU/GPU time y nivel de batería en CSV y muestra valores en pantalla.
+public class QuestPerfLogger : MonoBehaviour
+{
+    [Tooltip("Tiempo entre muestras en segundos")]
+    public float logInterval = 1f;
+
+    string _filePath;
+    float _nextLogTime;
+    float _lastCpu, _lastGpu, _lastBatt;
+
+    void Start()
+    {
+        _filePath = Path.Combine(Application.persistentDataPath, "QuestPerf.csv");
+        File.WriteAllText(_filePath, "Time,AppCPU_ms,AppGPU_ms,Battery\n");
+        _nextLogTime = Time.time + logInterval;
+    }
+
+    void Update()
+    {
+        if (Time.time >= _nextLogTime)
+        {
+            _nextLogTime = Time.time + logInterval;
+
+            XRStats.TryGetAppCPUTimeLastFrame(out float cpuMs);
+            XRStats.TryGetAppGPUTimeLastFrame(out float gpuMs);
+            float batt = SystemInfo.batteryLevel;
+
+            File.AppendAllText(_filePath, string.Format("{0:F2},{1:F3},{2:F3},{3:F2}\n", Time.time, cpuMs, gpuMs, batt));
+
+            _lastCpu = cpuMs;
+            _lastGpu = gpuMs;
+            _lastBatt = batt;
+        }
+    }
+
+    void OnGUI()
+    {
+        GUILayout.BeginVertical("box");
+        GUILayout.Label($"CPU: {_lastCpu:F2} ms");
+        GUILayout.Label($"GPU: {_lastGpu:F2} ms");
+        GUILayout.Label($"Batería: {_lastBatt:P0}");
+        GUILayout.Label($"Log: {_filePath}");
+        GUILayout.EndVertical();
+    }
+}

--- a/Assets/1-Programming/QuestPerfLogger.cs.meta
+++ b/Assets/1-Programming/QuestPerfLogger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7c2af3e2c74d4103a7b23d2c9c24f83a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -31,3 +31,18 @@ Desactiva funciones que no necesitas en `Settings → Features`:
 
 
 </footer>
+
+## Pruebas recomendadas para Quest 3 (VR)
+
+Este proyecto incluye utilidades para medir rendimiento. Para Oculus Quest 3 es recomendable diseñar pruebas que cubran:
+
+- **Fill‑rate y resolución**: medir escenas con muchos píxeles (quads a pantalla completa) para detectar cuellos de botella en GPU.
+- **Complejidad geométrica**: usar rejillas de mallas con distintos números de vértices para estresar la carga de CPU/GPU.
+- **Iluminación y post‑proceso**: comparar distintos números de luces, sombras y efectos URP.
+- **Sistemas de partículas/VFX**: evaluar costes de efectos visuales frecuentes en VR.
+- **Memoria y streaming**: comprobar impacto de texturas o modelos de gran tamaño.
+
+### Logger de métricas en dispositivo
+
+El script `QuestPerfLogger` guarda en `persistentDataPath/QuestPerf.csv` los tiempos de CPU/GPU y el nivel de batería. Añádelo a la escena principal para tener un HUD básico y un registro de datos durante las pruebas.
+


### PR DESCRIPTION
## Summary
- add QuestPerfLogger script to log CPU/GPU time and battery level on Quest
- document recommended Quest 3 benchmark scenarios and logger usage

## Testing
- `mcs Benchmark/Assets/1-Programming/QuestPerfLogger.cs` *(fails: command not found)*
- `csc Benchmark/Assets/1-Programming/QuestPerfLogger.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c170188c4c832698ef078d4ada592c