### PR TITLE
Añade análisis de rendimiento y redondeo de métricas para Quest 3

### DIFF
--- a/Assets/3-Scenes/Main.unity
+++ b/Assets/3-Scenes/Main.unity
@@ -444,8 +444,8 @@ MonoBehaviour:
   uploadBatchSize: 32
   newSheetPerRun: 1
   sheetNamePrefix: Run_
-  customRunLabel: 
-  targetFPS: 60
+  customRunLabel:
+  targetFPS: 72
 --- !u!4 &1662094702
 Transform:
   m_ObjectHideFlags: 0

--- a/README.md
+++ b/README.md
@@ -46,3 +46,12 @@ Este proyecto incluye utilidades para medir rendimiento. Para Oculus Quest 3 es 
 
 El script `QuestPerfLogger` guarda en `persistentDataPath/QuestPerf.csv` los tiempos de CPU/GPU y el nivel de batería. Añádelo a la escena principal para tener un HUD básico y un registro de datos durante las pruebas.
 
+### Análisis automático en Google Sheets
+
+Los datos enviados a la hoja de cálculo ahora incluyen:
+
+- Valores de tiempo redondeados para facilitar la lectura.
+- Detección del cuello de botella (CPU o GPU).
+- Una valoración rápida sobre si el rendimiento es adecuado para Quest 3.
+- Un campo de resumen con la comparación contra el presupuesto de tiempo de frame.
+


### PR DESCRIPTION
## Resumen
- Redondeo de tiempos y FPS al generar filas y CSV
- Nuevo análisis automático que determina cuello de botella, valoración para Quest 3 y resumen
- Objetivo de FPS predeterminado actualizado a 72 y documentación del análisis en README

## Pruebas
- `npm test` (falla: no existe package.json)
- `dotnet test` (falla: comando no encontrado)


------
https://chatgpt.com/codex/tasks/task_b_68c2ea59d36c8326adb65372aedd97b3